### PR TITLE
Modification for UTF-8 filename, multibyte file, gvim on Windows and GitVimDiff

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,6 +12,7 @@ Git-vim provides:
 [:GitLog]              Show git-log of current file or repository.
 [:GitCheckout <args>]  git-checkout. Completes git commits.
 [:GitDiff <args>]      git-diff. Completes git commits.
+[:GitVimDiff <args>]   git-diff in vimdiff mode.
 [:GitPull <args>]      git-pull.
 [:GitPullRebase]       git-pull --rebase.
 [:GitPush <args>]      git-push. Defaults to +git push origin <current-branch>+.

--- a/doc/git-vim.txt
+++ b/doc/git-vim.txt
@@ -37,11 +37,14 @@ Git-vim provides:
 :GitDiff <args>
     git-diff. Completes git commits.
 
+:GitVimDiff <args>
+    git-diff in vimdiff mode.
+
 :GitPull <args>
     git-pull.
 
 :GitPullRebase
-    git-pull —rebase.
+    git-pull --rebase.
 
 :GitPush <args>
     git-push. Defaults to +git push origin <current-branch>+.
@@ -65,7 +68,7 @@ Git-vim provides:
     :GitDiff
 
 <Leader>gD
-    :GitDiff —cached
+    :GitDiff --cached
 
 <Leader>gs
     :GitStatus


### PR DESCRIPTION
GitVimDiff. (&enconding must be set to utf-8 in .vimrc, etc)

Fixed typo in git-vim.txt
    git-pull --rebase
    :GitDiff --cached

Imported GitVimDiff of harajune-san.

Supported GitVimDiff on gvim on MS-Windows.

Supported UTF-8 filename.

Supported multibyte code in file.
So, You can read code in sjis, euc-jp and utf-8 with GitDiff, GitVimDiff and GitCatFile.

Fixed an issue of extra CR in GitDiff, GitVimDiff and GitCatFile
on cygwin vim.

GitVimDiff is described in README.rdoc.
